### PR TITLE
Refresh Explore Group page join status after leaving a group

### DIFF
--- a/lib/v4/social/explore/recommended_communities/amity_recommended_communities_component.dart
+++ b/lib/v4/social/explore/recommended_communities/amity_recommended_communities_component.dart
@@ -64,6 +64,9 @@ class AmityRecommendedCommunitiesComponent extends NewBaseComponent {
                         AmityRecommendedCommunityCard(
                       theme: theme,
                       community: state.communities[index],
+                      refreshController: context
+                          .read<RecommendedCommunitiesCubit>()
+                          .refreshController,
                       onJoinTap: () => context
                           .read<RecommendedCommunitiesCubit>()
                           .joinCommunity(state.communities[index].communityId!),
@@ -83,12 +86,14 @@ class AmityRecommendedCommunityCard extends StatelessWidget {
   final AmityThemeColor theme;
   final AmityCommunity community;
   final VoidCallback onJoinTap;
+  final ExploreComponentRefreshController? refreshController;
 
   const AmityRecommendedCommunityCard({
     Key? key,
     required this.theme,
     required this.community,
     required this.onJoinTap,
+    this.refreshController,
   }) : super(key: key);
 
   @override
@@ -102,7 +107,9 @@ class AmityRecommendedCommunityCard extends StatelessWidget {
             context,
             MaterialPageRoute(
                 builder: (context) => AmityCommunityProfilePage(
-                    communityId: community.communityId ?? '')));
+                    communityId: community.communityId ?? ''))).then((_) {
+          refreshController?.notifyRefresh();
+        });
       },
       child: Container(
         width: 268,

--- a/lib/v4/social/explore/trending_communities/amity_trending_communities_component.dart
+++ b/lib/v4/social/explore/trending_communities/amity_trending_communities_component.dart
@@ -85,7 +85,12 @@ class AmityTrendingCommunitiesView extends StatelessWidget {
                       builder: (context) => AmityCommunityProfilePage(
                         communityId: entry.value.communityId!,
                       ),
-                    ));
+                    )).then((_) {
+                      context
+                          .read<TrendingCommunitiesCubit>()
+                          .refreshController
+                          ?.notifyRefresh();
+                    });
                   },
                   onJoinTap: () {
                     if (entry.value.isJoined == true) {


### PR DESCRIPTION
https://socialplus.atlassian.net/browse/SLE-314

Issue
When a user leaves a community from the Community Settings page, the app navigates back to the Explore page, but the join status is not updated because the Explore page is not refreshed.

Cause
The onSuccess callback pops the navigation back to Explore, but no refresh is triggered. CommunitySettingPageBloc only calls leaveCommunity() and handles navigation.

Fix
Trigger a refresh of the Explore page after leaving the community so the join status updates correctly.