### PR TITLE
fix: PDT-3085 - Adding a link with renders not full preview of the page (not fully stretched)

### DIFF
--- a/lib/v4/core/ui/preview_link_widget.dart
+++ b/lib/v4/core/ui/preview_link_widget.dart
@@ -136,7 +136,8 @@ class _PreviewLinkWidgetState extends State<PreviewLinkWidget> {
     if (_metadata != null && _metadata!.image != null) {
       return Image.network(
         _metadata!.image!,
-        fit: BoxFit.contain,
+        width:double.infinity,
+        fit: BoxFit.cover,
         errorBuilder: (context, error, stackTrace) {
           return _buildPlaceholderImage(false);
         },


### PR DESCRIPTION
Fix link preview header image not filling full width on iOS/Android

This PR fixes an issue where the link preview header image does not expand to the full width of the container and appears constrained to its intrinsic image size.

Issue

The issue can be reproduced on iOS (and affects Android behavior as well).

Root cause

In preview_link_widget.dart → _buildHeaderImage(), the Image.network widget was configured with:

* fit: BoxFit.contain
* no explicit width

Because of this, the image only renders at its intrinsic width instead of expanding to fill the available horizontal space.

Fix

Updated the image configuration to:

* width: double.infinity
* fit: BoxFit.cover

This ensures the header image stretches to fill the container width while maintaining a banner-style appearance through cropping.

Before: 
<img width="319" height="630" alt="Screenshot 2569-05-26 at 15 06 55" src="https://github.com/user-attachments/assets/b8547dbe-a3e2-42c8-93be-f0690a400d33" />

After 
<img width="354" height="688" alt="Screenshot 2569-05-26 at 15 04 22" src="https://github.com/user-attachments/assets/5c51ad45-aaa8-479e-8bb5-7202b87f5554" />
