### PR TITLE
feat(v4/core): allow the host app to switch the UIKit theme at runtime

### DIFF
--- a/lib/amity_uikit.dart
+++ b/lib/amity_uikit.dart
@@ -15,6 +15,7 @@ import 'package:amity_uikit_beta_service/v4/social/story/hyperlink/bloc/hyperlin
 import 'package:amity_uikit_beta_service/v4/social/story/view/components/story_video_player/bloc/story_video_player_bloc.dart';
 import 'package:amity_uikit_beta_service/v4/utils/config_provider.dart';
 import 'package:amity_uikit_beta_service/v4/utils/create_story/bloc/create_story_bloc.dart';
+import 'package:amity_uikit_beta_service/v4/utils/theme_preference.dart';
 import 'package:amity_uikit_beta_service/viewmodel/category_viewmodel.dart';
 import 'package:amity_uikit_beta_service/viewmodel/chat_room_viewmodel.dart';
 import 'package:amity_uikit_beta_service/viewmodel/community_feed_viewmodel.dart';
@@ -57,6 +58,13 @@ enum AmityEndpointRegion {
 class AmityUIKit {
   static List<CameraDescription> cameras = <CameraDescription>[];
 
+  /// Sets the SDK screens' theme at runtime. Accepts `'light'`, `'dark'`,
+  /// `'system'`, or `null` (uses the value from `config.json`). The host app
+  /// should call this method whenever the app's theme changes.
+  static void setPreferredTheme(String? preferredTheme) {
+    AmityThemePreference.set(preferredTheme);
+  }
+
   Future<void> setup({
     required String apikey,
     required AmityEndpointRegion region,
@@ -68,13 +76,14 @@ class AmityUIKit {
     Stopwatch stopwatch = Stopwatch()..start();
     AmityRegionalHttpEndpoint? amityEndpoint;
     AmityRegionalMqttEndpoint? amityMqttEndpoint;
-    AmityUploadEndpoint? amityUploadEndpoint;    
+    AmityUploadEndpoint? amityUploadEndpoint;
 
     switch (region) {
       case AmityEndpointRegion.custom:
         if (customEndpoint != null &&
             customMqttEndpoint != null &&
-            customSocketEndpoint != null && customUploadEndpoint != null) {
+            customSocketEndpoint != null &&
+            customUploadEndpoint != null) {
           amityEndpoint = AmityRegionalHttpEndpoint.custom(customEndpoint);
           amityMqttEndpoint =
               AmityRegionalMqttEndpoint.custom(customMqttEndpoint);
@@ -300,19 +309,19 @@ class AmityUIKitProvider extends StatelessWidget {
             supportedLocales: const [
               Locale('en'),
               Locale('pt'), // Base Portuguese locale
-              Locale('pt', 'BR'),  // Portuguese (Brazil)
-              Locale('es'),        // Base Spanish locale
-              Locale('es', 'CL'),  // Spanish (Chile)
-              Locale('es', 'CO'),  // Spanish (Colombia)
-              Locale('es', 'MX'),  // Spanish (Mexico)
-              Locale('es', 'PE'),  // Spanish (Peru)
+              Locale('pt', 'BR'), // Portuguese (Brazil)
+              Locale('es'), // Base Spanish locale
+              Locale('es', 'CL'), // Spanish (Chile)
+              Locale('es', 'CO'), // Spanish (Colombia)
+              Locale('es', 'MX'), // Spanish (Mexico)
+              Locale('es', 'PE'), // Spanish (Peru)
             ],
             // Ensure the app uses the device locale by default
             localeResolutionCallback: (deviceLocale, supportedLocales) {
               if (deviceLocale != null) {
                 for (var locale in supportedLocales) {
-                  print ("deviceLocale: ${deviceLocale.languageCode}");
-                  print ("supportedLocales: $supportedLocales}");
+                  print("deviceLocale: ${deviceLocale.languageCode}");
+                  print("supportedLocales: $supportedLocales}");
                   // Check for exact matches first
                   if (locale.languageCode == deviceLocale.languageCode &&
                       locale.countryCode == deviceLocale.countryCode) {

--- a/lib/v4/chat/message/components/amity_conversation_chat_user_action_component.dart
+++ b/lib/v4/chat/message/components/amity_conversation_chat_user_action_component.dart
@@ -1,7 +1,6 @@
 import 'package:amity_sdk/amity_sdk.dart';
 import 'package:amity_uikit_beta_service/l10n/localization_helper.dart';
 import 'package:amity_uikit_beta_service/v4/core/base_component.dart';
-import 'package:amity_uikit_beta_service/v4/core/config_repository.dart';
 import 'package:amity_uikit_beta_service/v4/core/styles.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -26,11 +25,9 @@ class AmityConversationChatUserActionComponent extends NewBaseComponent {
 
   @override
   Widget buildComponent(BuildContext context) {
-    final configRepo = ConfigRepository();
-    final showMute = configRepo.isChatUserActionEnabled('mute');
-    final showReport = configRepo.isChatUserActionEnabled('report');
-    final showBlock = configRepo.isChatUserActionEnabled('block');
-
+    final showMute = configProvider.isChatUserActionEnabled('mute');
+    final showReport = configProvider.isChatUserActionEnabled('report');
+    final showBlock = configProvider.isChatUserActionEnabled('block');
 
     return Container(
       padding:
@@ -142,8 +139,8 @@ class AmityConversationChatUserActionComponent extends NewBaseComponent {
                           package: 'amity_uikit_beta_service',
                           width: 24,
                           height: 24,
-                          colorFilter:
-                              ColorFilter.mode(theme.baseColor, BlendMode.srcIn)),
+                          colorFilter: ColorFilter.mode(
+                              theme.baseColor, BlendMode.srcIn)),
                     ),
                     const SizedBox(width: 12),
                     Expanded(

--- a/lib/v4/chat/message/widgets/chat_page_helpers.dart
+++ b/lib/v4/chat/message/widgets/chat_page_helpers.dart
@@ -4,11 +4,10 @@ extension ChatPageHelpers on AmityChatPage {
   void _showChatUserActionBottomSheet(
       BuildContext context, ChatPageState state) {
     final chatPageBloc = context.read<ChatPageBloc>();
-    final configRepo = ConfigRepository();
 
-    final showMute = configRepo.isChatUserActionEnabled('mute');
-    final showReport = configRepo.isChatUserActionEnabled('report');
-    final showBlock = configRepo.isChatUserActionEnabled('block');
+    final showMute = configProvider.isChatUserActionEnabled('mute');
+    final showReport = configProvider.isChatUserActionEnabled('report');
+    final showBlock = configProvider.isChatUserActionEnabled('block');
 
     if (!showMute && !showReport && !showBlock) {
       return;
@@ -342,7 +341,9 @@ extension ChatPageHelpers on AmityChatPage {
       {shouldAnimated = false, int millisecBeforeAnimated = 0}) {
     state.scrollController
         .animateTo(
-      (state.useReverseUI && state.contentOverflowsScreen) ? 0.0 : state.scrollController.position.maxScrollExtent,
+      (state.useReverseUI && state.contentOverflowsScreen)
+          ? 0.0
+          : state.scrollController.position.maxScrollExtent,
       curve: Curves.easeOut,
       duration: const Duration(milliseconds: 300),
     )

--- a/lib/v4/core/base_component.dart
+++ b/lib/v4/core/base_component.dart
@@ -23,21 +23,19 @@ class BaseComponent extends StatelessWidget {
 abstract class NewBaseComponent extends StatelessWidget {
   final String? pageId;
   final String componentId;
-  late final AmityThemeColor theme;
-  late final ConfigProvider configProvider;
-  late final Map<String, dynamic> config;
-  late final AmityUIConfig uiConfig;
+  late AmityThemeColor theme;
+  late ConfigProvider configProvider;
+  late Map<String, dynamic> config;
+  late AmityUIConfig uiConfig;
 
   NewBaseComponent({super.key, this.pageId, required this.componentId});
 
   @override
   Widget build(BuildContext context) {
-    if (!isInitialized()) {
-      configProvider = context.watch<ConfigProvider>();
-      theme = configProvider.getTheme(pageId, componentId);
-      config = configProvider.getMapConfig(pageId, componentId, null);
-      uiConfig = configProvider.getUIConfig(pageId, componentId, null);
-    }
+    configProvider = context.watch<ConfigProvider>();
+    theme = configProvider.getTheme(pageId, componentId);
+    config = configProvider.getMapConfig(pageId, componentId, null);
+    uiConfig = configProvider.getUIConfig(pageId, componentId, null);
     return Theme(
         data: Theme.of(context).copyWith(
             textSelectionTheme: TextSelectionThemeData(
@@ -49,16 +47,4 @@ abstract class NewBaseComponent extends StatelessWidget {
   }
 
   Widget buildComponent(BuildContext context);
-
-  bool isInitialized() {
-    try {
-      configProvider;
-      theme;
-      config;
-      uiConfig;
-      return true;
-    } catch (e) {
-      return false;
-    }
-  }
 }

--- a/lib/v4/core/base_element.dart
+++ b/lib/v4/core/base_element.dart
@@ -8,9 +8,9 @@ abstract class BaseElement extends StatelessWidget {
   final String? componentId;
   final String elementId;
 
-  late final AmityThemeColor theme;
-  late final ConfigProvider configProvider;
-  late final AmityUIConfig uiConfig;
+  late AmityThemeColor theme;
+  late ConfigProvider configProvider;
+  late AmityUIConfig uiConfig;
 
   BaseElement(
       {super.key, this.pageId, this.componentId, required this.elementId});

--- a/lib/v4/core/base_page.dart
+++ b/lib/v4/core/base_page.dart
@@ -26,9 +26,9 @@ abstract class NewBasePage extends StatelessWidget {
 
   NewBasePage({super.key, required this.pageId});
 
-  late final ConfigProvider configProvider;
-  late final AmityThemeColor theme;
-  late final AmityUIConfig uiConfig;
+  late ConfigProvider configProvider;
+  late AmityThemeColor theme;
+  late AmityUIConfig uiConfig;
 
   Widget buildPage(BuildContext context);
 
@@ -36,11 +36,9 @@ abstract class NewBasePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer<ConfigProvider>(
       builder: (context, provider, child) {
-        if (!isInitialized()) {
-          configProvider = provider;
-          theme = configProvider.getTheme(pageId, '');
-          uiConfig = configProvider.getUIConfig(pageId, null, null);
-        }
+        configProvider = provider;
+        theme = configProvider.getTheme(pageId, '');
+        uiConfig = configProvider.getUIConfig(pageId, null, null);
         return Theme(
             data: Theme.of(context).copyWith(
                 textSelectionTheme: TextSelectionThemeData(
@@ -51,28 +49,6 @@ abstract class NewBasePage extends StatelessWidget {
             child: buildPage(context));
       },
     );
-    // return ChangeNotifierProvider<ConfigProvider>(
-    //   create: (_) {
-    //     configProvider.loadConfig();
-    //     return configProvider;
-    //   },
-    //   child: Consumer<ConfigProvider>(
-    //     builder: (context, configProvider, child) {
-    //       return buildPage(context);
-    //     },
-    //   ),
-    // );
-  }
-
-  bool isInitialized() {
-    try {
-      configProvider;
-      theme;
-      uiConfig;
-      return true;
-    } catch (e) {
-      return false;
-    }
   }
 }
 

--- a/lib/v4/core/config_repository.dart
+++ b/lib/v4/core/config_repository.dart
@@ -6,15 +6,16 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 
 class ConfigRepository {
-  static final ConfigRepository _instance = ConfigRepository._internal();
+  ConfigRepository();
 
-  factory ConfigRepository() => _instance;
-
-  ConfigRepository._internal();
-
-  late Map<String, dynamic> _config;
-  late Set<String> excludedList;
+  Map<String, dynamic> _config = {};
+  Set<String> excludedList = {};
   bool _isConfigInitialized = false;
+
+  /// Preferred theme set by the host app at runtime. Takes precedence over the
+  /// `preferred_theme` value from `config.json`. `null` keeps the value from the
+  /// configuration file.
+  String? _preferredThemeOverride;
 
   Future<void> loadConfig() async {
     if (!_isConfigInitialized) {
@@ -22,6 +23,13 @@ class ConfigRepository {
       excludedList = Set<String>.from(_config['excludes'] ?? []);
       _isConfigInitialized = true;
     }
+  }
+
+  /// Changes the preferred theme at runtime. Accepts `'light'`, `'dark'`,
+  /// `'system'`, or `null` (reverts to the value from `config.json`). Stored
+  /// separately so it persists across a potential config reload.
+  void setPreferredTheme(String? preferredTheme) {
+    _preferredThemeOverride = preferredTheme;
   }
 
   Map<String, dynamic> getFeatureFlags() {
@@ -76,9 +84,11 @@ extension ThemeConfig on ConfigRepository {
   AmityThemeStyle _getCurrentThemeStyle() {
     final systemStyle =
         SchedulerBinding.instance.platformDispatcher.platformBrightness;
-    final configStyle = _config['preferred_theme'] == 'dark'
+    final preferredTheme =
+        _preferredThemeOverride ?? _config['preferred_theme'];
+    final configStyle = _preferredThemeOverride == 'dark'
         ? AmityThemeStyle.dark
-        : _config['preferred_theme'] == 'light'
+        : preferredTheme == 'light'
             ? AmityThemeStyle.light
             : AmityThemeStyle.system;
 
@@ -96,8 +106,7 @@ extension ThemeConfig on ConfigRepository {
     final fallbackTheme = _getCurrentThemeStyle() == AmityThemeStyle.light
         ? lightTheme
         : darkTheme;
-    final globalTheme =
-        _getGlobalTheme(_getCurrentThemeStyle(), fallbackTheme);
+    final globalTheme = _getGlobalTheme(_getCurrentThemeStyle(), fallbackTheme);
 
     if (configId == null) {
       return _getThemeColor(globalTheme, fallbackTheme);
@@ -121,7 +130,8 @@ extension ThemeConfig on ConfigRepository {
       if (componentTheme != null) {
         final theme = _getThemeColor(
             AmityTheme.fromJson(
-                componentTheme["theme"]?[style.toString().split('.').last], fallbackTheme),
+                componentTheme["theme"]?[style.toString().split('.').last],
+                fallbackTheme),
             fallbackTheme);
         return theme;
       }
@@ -129,7 +139,8 @@ extension ThemeConfig on ConfigRepository {
       if (pageTheme != null) {
         return _getThemeColor(
             AmityTheme.fromJson(
-                pageTheme["theme"]?[style.toString().split('.').last], fallbackTheme),
+                pageTheme["theme"]?[style.toString().split('.').last],
+                fallbackTheme),
             fallbackTheme);
       }
     } catch (error) {
@@ -257,7 +268,8 @@ extension ConversationChatUserActionConfig on ConfigRepository {
       String name = item['name'] ?? '';
       bool enabled = item['enabled'] ?? true;
       if (name.isNotEmpty) {
-        actionsMap[name] = AmityChatUserActionType(name: name, enabled: enabled);
+        actionsMap[name] =
+            AmityChatUserActionType(name: name, enabled: enabled);
       }
     }
     return actionsMap;

--- a/lib/v4/utils/config_provider.dart
+++ b/lib/v4/utils/config_provider.dart
@@ -1,10 +1,36 @@
 import 'package:amity_uikit_beta_service/v4/core/config_repository.dart';
 import 'package:amity_uikit_beta_service/v4/core/theme.dart';
+import 'package:amity_uikit_beta_service/v4/utils/theme_preference.dart';
 import 'package:flutter/material.dart';
 
 class ConfigProvider extends ChangeNotifier {
   final ConfigRepository _configRepository = ConfigRepository();
   bool _isConfigInitialized = false;
+
+  ConfigProvider() {
+    // Applies the theme pushed by the host app before this provider was created
+    // and starts listening for runtime theme changes.
+    _onPreferredThemeChanged();
+    AmityThemePreference.notifier.addListener(_onPreferredThemeChanged);
+  }
+
+  void _onPreferredThemeChanged() {
+    _configRepository.setPreferredTheme(AmityThemePreference.notifier.value);
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    AmityThemePreference.notifier.removeListener(_onPreferredThemeChanged);
+    super.dispose();
+  }
+
+  /// Changes the SDK's preferred theme at runtime (`'light'`, `'dark'`,
+  /// `'system'`, or `null`) and re-renders the screens.
+  void setPreferredTheme(String? preferredTheme) {
+    _configRepository.setPreferredTheme(preferredTheme);
+    notifyListeners();
+  }
 
   Future<void> loadConfig() async {
     if (!_isConfigInitialized) {
@@ -12,6 +38,14 @@ class ConfigProvider extends ChangeNotifier {
       notifyListeners();
       _isConfigInitialized = true;
     }
+  }
+
+  bool isChatUserActionEnabled(String actionName) {
+    return _configRepository.isChatUserActionEnabled(actionName);
+  }
+
+  bool hasAnyEnabledChatUserAction() {
+    return _configRepository.hasAnyEnabledChatUserAction();
   }
 
   Map<String, dynamic> getConfig(String configId) {

--- a/lib/v4/utils/theme_preference.dart
+++ b/lib/v4/utils/theme_preference.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/foundation.dart';
+
+/// Runtime signaling channel between the host app and the SDK for the
+/// preferred theme.
+///
+/// The SDK is a lower-level dependency than the app, so it cannot import the
+/// app's `AppThemeMode`/`AppTheme`. This notifier serves as the entry point:
+/// the app pushes the effective theme (`'light'`, `'dark'`, `'system'`, or
+/// `null` to use the value from `config.json`) whenever the user changes the
+/// theme, and the [ConfigProvider] listens for updates and re-renders the
+/// screens.
+///
+/// Stores only the preferred theme value—not the SDK configuration, which is
+/// no longer a singleton and now lives within the [ConfigProvider] instance.
+class AmityThemePreference {
+  AmityThemePreference._();
+
+  static final ValueNotifier<String?> notifier = ValueNotifier<String?>(null);
+
+  /// Sets the preferred theme at runtime. Accepts `'light'`, `'dark'`, `'system'`,
+  /// or `null` (uses the value from `config.json`).
+  static void set(String? preferredTheme) {
+    notifier.value = preferredTheme;
+  }
+}


### PR DESCRIPTION
## Summary

Today the UIKit resolves its theme **once**, from `preferred_theme` in `config.json`,
and caches the resulting `AmityThemeColor` on the first build of every page,
component and element. As a consequence, an app that lets the user switch between
light and dark mode at runtime cannot propagate that choice to the UIKit screens —
they keep rendering with whatever theme was resolved on the very first build, until
the app is restarted.

This PR makes the preferred theme a **runtime-changeable value**. The host app pushes
the theme it wants, the UIKit re-resolves its colors and re-renders. When the app never
pushes anything, behaviour is exactly the same as today (the `config.json` value is used).

All changes are contained in `amity_uikit_beta_service` and are **additive to the public
API** — no existing entry point changed its signature.

## Public API

A single new entry point:

```dart
// 'light' | 'dark' | 'system' | null (null falls back to config.json)
AmityUIKit.setPreferredTheme('dark');

It can be called at any time — before or after AmityUIKit.setup(), and as many times
as the user toggles the theme in the host app.

ConfigProvider.setPreferredTheme(String?) is also exposed, for hosts that already hold
a reference to the provider.

What changed

1. New runtime signal channel — v4/utils/theme_preference.dart

AmityThemePreference is a tiny static ValueNotifier<String?> that carries the
preferred theme from the host app into the SDK. It exists because the UIKit is a
lower-level dependency than the app and therefore cannot import the app's own theme
model. It holds only the theme value — no SDK configuration.

2. ConfigProvider listens to that channel

The provider subscribes to AmityThemePreference.notifier in its constructor, applies
any value pushed before the provider existed, forwards it to ConfigRepository and
calls notifyListeners(). The listener is removed in dispose().

It also gained two thin delegations already available on the repository —
isChatUserActionEnabled and hasAnyEnabledChatUserAction — so widgets can read
config through the injected provider instead of reaching for the repository directly.

3. ConfigRepository — runtime override + no longer a singleton

- New setPreferredTheme(String?), stored in a dedicated _preferredThemeOverride
field so it survives a config reload. _getCurrentThemeStyle() now reads
_preferredThemeOverride ?? _config['preferred_theme'], i.e. the runtime value takes
precedence over the file, and null restores the file value.
- The _instance singleton and the redirecting factory were removed; the repository is
now instantiated by whoever owns it (in practice, ConfigProvider). _config and
excludedList moved from late to initialized defaults ({}), which also removes a
class of LateInitializationError when a getter is hit before loadConfig() completes.

4. Base classes no longer cache the resolved theme

NewBasePage, NewBaseComponent and BaseElement used to guard their assignments with
isInitialized() — a try/catch around late final fields — so theme, config,
uiConfig and configProvider were resolved exactly once per widget instance and never
again. Those fields are now plain late (non-final) and are recomputed on every build,
so a ConfigProvider notification actually reaches the UI. The now-unused
isInitialized() helpers and a block of commented-out code in base_page.dart were
removed.

5. Call sites

AmityConversationChatUserActionComponent and chat_page_helpers.dart instantiated
AmityConversationChatUserActionComponent and chat_page_helpers.dart instantiated
ConfigRepository() inline (relying on the singleton). They now read from the injected
configProvider, which is required for the repository to stop being a singleton.

Behavioural impact

- No change for apps that never call setPreferredTheme — the override is null
and config.json remains the source of truth, including 'system'.
- Rebuild cost: base widgets now re-resolve theme/config on each build instead of once.
In our usage the extra work is a few map lookups per build and we measured no
noticeable impact; happy to move to a memoized value keyed by the current theme style
if you would rather not pay it on every frame.
- ConfigRepository() no longer returns a shared instance. Any code outside the files
touched here that constructs it directly and expects the already-loaded config will now
get a fresh, empty instance — we believe ConfigProvider is the only owner, but this is
the point we would most like reviewed on your side.

How to test

1. Open any v4 page (social feed, chat, story) with preferred_theme: "light" in
config.json.
2. Call AmityUIKit.setPreferredTheme('dark') from the host app while the page is on
screen — the page and its components should repaint in dark immediately, with no
navigation or restart.
3. Call AmityUIKit.setPreferredTheme(null) — the screens should go back to the
config.json value.
4. With 'system' selected, change the OS appearance and confirm the screens follow.