### PR TITLE
chore: Apply changes from version 4.20.20

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,9 +31,24 @@ import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 
 List<CameraDescription> camera = <CameraDescription>[];
+
+const _preferredThemePrefKey = 'preferredTheme';
+
+Future<void> _restorePreferredTheme() async {
+  final prefs = await SharedPreferences.getInstance();
+  final saved = prefs.getString(_preferredThemePrefKey);
+  if (saved != null) {
+    AmityUIKit().setPreferredTheme(
+        AmityThemeStyle.values.asNameMap()[saved] ?? AmityThemeStyle.system);
+  }
+}
+
 void main() async {
   ///Step 1: Initialize amity SDK with the following function
   WidgetsFlutterBinding.ensureInitialized();
+
+  await _restorePreferredTheme();
+
   // await Firebase.initializeApp(
   // options: DefaultFirebaseOptions.currentPlatform,
   // );
@@ -484,9 +499,36 @@ class _UserListPageState extends State<UserListPage> {
   }
 }
 
-class SecondPage extends StatelessWidget {
+class SecondPage extends StatefulWidget {
   const SecondPage({super.key, required this.username});
   final String username;
+
+  @override
+  State<SecondPage> createState() => _SecondPageState();
+}
+
+class _SecondPageState extends State<SecondPage> {
+  AmityThemeStyle _theme = AmityThemeStyle.system;
+
+  @override
+  void initState() {
+    super.initState();
+    SharedPreferences.getInstance().then((prefs) {
+      final saved = prefs.getString(_preferredThemePrefKey);
+      if (saved != null && mounted) {
+        setState(() => _theme =
+            AmityThemeStyle.values.asNameMap()[saved] ?? AmityThemeStyle.system);
+      }
+    });
+  }
+
+  Future<void> _setTheme(AmityThemeStyle style) async {
+    setState(() => _theme = style);
+    AmityUIKit().setPreferredTheme(style);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_preferredThemePrefKey, style.name);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -500,7 +542,7 @@ class SecondPage extends StatelessWidget {
             );
           },
         ),
-        title: Text('Welcome, $username'),
+        title: Text('Welcome, ${widget.username}'),
       ),
       body: Center(
         child: Column(
@@ -510,7 +552,8 @@ class SecondPage extends StatelessWidget {
               onPressed: () {
                 Navigator.of(context).push(
                   MaterialPageRoute(
-                    builder: (context) => SocialPage(username: username),
+                    builder: (context) =>
+                        SocialPage(username: widget.username),
                   ),
                 );
               },
@@ -520,11 +563,25 @@ class SecondPage extends StatelessWidget {
               onPressed: () {
                 Navigator.of(context).push(
                   MaterialPageRoute(
-                    builder: (context) => ChatPage(username: username),
+                    builder: (context) => ChatPage(username: widget.username),
                   ),
                 );
               },
               child: const Text('Chat'),
+            ),
+            const SizedBox(height: 24),
+            const Text('Theme'),
+            SegmentedButton<AmityThemeStyle>(
+              segments: const [
+                ButtonSegment(
+                    value: AmityThemeStyle.light, label: Text('Light')),
+                ButtonSegment(
+                    value: AmityThemeStyle.dark, label: Text('Dark')),
+                ButtonSegment(
+                    value: AmityThemeStyle.system, label: Text('Default')),
+              ],
+              selected: {_theme},
+              onSelectionChanged: (selection) => _setTheme(selection.first),
             ),
           ],
         ),

--- a/lib/amity_uikit.dart
+++ b/lib/amity_uikit.dart
@@ -7,6 +7,9 @@ import 'package:amity_uikit_beta_service/uikit_behavior.dart';
 import 'package:amity_uikit_beta_service/l10n/generated/app_localizations.dart';
 import 'package:amity_uikit_beta_service/utils/navigation_key.dart';
 import 'package:amity_uikit_beta_service/v4/chat/message/parent_message_cache.dart';
+import 'package:amity_uikit_beta_service/v4/core/config_repository.dart';
+import 'package:amity_uikit_beta_service/v4/core/theme.dart'
+    show AmityThemeStyle;
 import 'package:amity_uikit_beta_service/v4/core/toast/bloc/amity_uikit_toast_bloc.dart';
 import 'package:amity_uikit_beta_service/v4/social/globalfeed/bloc/global_feed_bloc.dart';
 import 'package:amity_uikit_beta_service/v4/social/social_home_page/bloc/social_home_bloc.dart';
@@ -46,6 +49,8 @@ import 'viewmodel/user_viewmodel.dart';
 
 export 'package:amity_sdk/src/domain/model/session/session_state.dart';
 export 'package:amity_sdk/src/core/enum/http_end_point.dart';
+export 'package:amity_uikit_beta_service/v4/core/theme.dart'
+    show AmityThemeStyle;
 
 enum AmityEndpointRegion {
   sg,
@@ -56,6 +61,15 @@ enum AmityEndpointRegion {
 
 class AmityUIKit {
   static List<CameraDescription> cameras = <CameraDescription>[];
+
+  /// Switches the UIKit theme at runtime, effective immediately.
+  ///
+  /// [AmityThemeStyle.light] / [AmityThemeStyle.dark] force a style;
+  /// [AmityThemeStyle.system] follows the device dark-mode setting.
+  /// Overrides `preferred_theme` from config.json until the app restarts.
+  void setPreferredTheme(AmityThemeStyle style) {
+    ConfigRepository().setPreferredTheme(style);
+  }
 
   Future<void> setup({
     required String apikey,

--- a/lib/v4/core/config_repository.dart
+++ b/lib/v4/core/config_repository.dart
@@ -16,6 +16,18 @@ class ConfigRepository {
   late Set<String> excludedList;
   bool _isConfigInitialized = false;
 
+  /// Preferred theme set at runtime via [setPreferredTheme]. Takes precedence
+  /// over `preferred_theme` from config.json; null means the config value.
+  /// A ValueNotifier so [ConfigProvider] can rebuild the UIKit tree on change.
+  final ValueNotifier<AmityThemeStyle?> preferredThemeNotifier =
+      ValueNotifier(null);
+
+  /// Changes the effective UIKit theme at runtime, effective immediately.
+  /// [AmityThemeStyle.system] follows the device dark-mode setting.
+  void setPreferredTheme(AmityThemeStyle style) {
+    preferredThemeNotifier.value = style;
+  }
+
   Future<void> loadConfig() async {
     if (!_isConfigInitialized) {
       _config = await _loadConfigFile('config');
@@ -76,11 +88,12 @@ extension ThemeConfig on ConfigRepository {
   AmityThemeStyle _getCurrentThemeStyle() {
     final systemStyle =
         SchedulerBinding.instance.platformDispatcher.platformBrightness;
-    final configStyle = _config['preferred_theme'] == 'dark'
-        ? AmityThemeStyle.dark
-        : _config['preferred_theme'] == 'light'
-            ? AmityThemeStyle.light
-            : AmityThemeStyle.system;
+    final configStyle = preferredThemeNotifier.value ??
+        (_config['preferred_theme'] == 'dark'
+            ? AmityThemeStyle.dark
+            : _config['preferred_theme'] == 'light'
+                ? AmityThemeStyle.light
+                : AmityThemeStyle.system);
 
     final style = configStyle == AmityThemeStyle.system
         ? (systemStyle == Brightness.light

--- a/lib/v4/utils/config_provider.dart
+++ b/lib/v4/utils/config_provider.dart
@@ -6,6 +6,18 @@ class ConfigProvider extends ChangeNotifier {
   final ConfigRepository _configRepository = ConfigRepository();
   bool _isConfigInitialized = false;
 
+  ConfigProvider() {
+    // Every base page/component/element watches this provider, so forwarding
+    // the repository's theme change here re-themes the whole UIKit tree.
+    _configRepository.preferredThemeNotifier.addListener(notifyListeners);
+  }
+
+  @override
+  void dispose() {
+    _configRepository.preferredThemeNotifier.removeListener(notifyListeners);
+    super.dispose();
+  }
+
   Future<void> loadConfig() async {
     if (!_isConfigInitialized) {
       await _configRepository.loadConfig();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amity_uikit_beta_service
 description: Amity UIkit opensource developed by SLE team to enable social feature in Flutter.
-version: 4.20.19
+version: 4.20.20
 homepage: https://github.com/ThanakornThanom/ThanakornThanom--flutter_amity_uikit_beta_service
 
 environment:

--- a/test/v4/core/set_preferred_theme_test.dart
+++ b/test/v4/core/set_preferred_theme_test.dart
@@ -1,0 +1,45 @@
+import 'package:amity_uikit_beta_service/v4/core/config_repository.dart';
+import 'package:amity_uikit_beta_service/v4/core/theme.dart';
+import 'package:amity_uikit_beta_service/v4/utils/config_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    // Asset is absent under test, so this initializes _config to {} —
+    // meaning no preferred_theme from config, i.e. system style.
+    await ConfigRepository().loadConfig();
+  });
+
+  test('setPreferredTheme overrides the resolved theme on the fly', () {
+    final repo = ConfigRepository();
+
+    repo.setPreferredTheme(AmityThemeStyle.dark);
+    expect(repo.getTheme(null).backgroundColor, darkTheme.backgroundColor);
+
+    repo.setPreferredTheme(AmityThemeStyle.light);
+    expect(repo.getTheme(null).backgroundColor, lightTheme.backgroundColor);
+  });
+
+  test('setPreferredTheme notifies ConfigProvider listeners', () {
+    final provider = ConfigProvider();
+    var notified = 0;
+    provider.addListener(() => notified++);
+
+    ConfigRepository().setPreferredTheme(AmityThemeStyle.dark);
+    expect(notified, 1);
+
+    // Same value again must not spam rebuilds.
+    ConfigRepository().setPreferredTheme(AmityThemeStyle.dark);
+    expect(notified, 1);
+
+    ConfigRepository().setPreferredTheme(AmityThemeStyle.system);
+    expect(notified, 2);
+
+    // Disposed providers must stop listening (no leak, no crash).
+    provider.dispose();
+    ConfigRepository().setPreferredTheme(AmityThemeStyle.light);
+    expect(notified, 2);
+  });
+}


### PR DESCRIPTION
## Release 4.20.20

Sync from private repo (4.20.19 patch line) to opensource.

### Added
- `AmityUIKit().setPreferredTheme(AmityThemeStyle.light|dark|system)` — runtime theme switching; overrides `preferred_theme` from config.json and re-themes the whole UIKit immediately (`system` follows device dark mode).

### Changes
- `lib/amity_uikit.dart`, `lib/v4/core/config_repository.dart`, `lib/v4/utils/config_provider.dart` — feature
- `test/v4/core/set_preferred_theme_test.dart` — unit test (2/2 pass)
- `example/lib/main.dart` — Light/Dark/Default theme picker in the sample
- `pubspec.yaml` — 4.20.19 → 4.20.20

### Checklist
- [x] pubspec.yaml version updated
- [x] All changed files copied from private
- [x] No private/internal files included